### PR TITLE
Update to work with k8s 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ collections:
     version: 1.1.2
 ```
 
-### Installing the OpenShift Python Library
+### Installing the Kubernetes Python Library
 
-Content in this collection requires the [OpenShift Python client](https://pypi.org/project/openshift/) to interact with Kubernetes' APIs. You can install it with:
+Content in this collection requires the [Kubernetes Python client](https://pypi.org/project/kubernetes/) to interact with Kubernetes' APIs. You can install it with:
 
-    pip3 install openshift
+    pip3 install kubernetes
 
 ### Using modules from the OKD Collection in your playbooks
 

--- a/changelogs/fragments/93-update-to-k8s-2.yaml
+++ b/changelogs/fragments/93-update-to-k8s-2.yaml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - drop python 2 support (https://github.com/openshift/community.okd/pull/93).
+major_changes:
+  - update to use kubernetes.core 2.0 (https://github.com/openshift/community.okd/pull/93).

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y \
       python3-setuptools \
  && pip3 install --no-cache-dir --upgrade setuptools pip \
  && pip3 install --no-cache-dir \
-      openshift \
+      kubernetes \
       ansible==2.9.* \
       "molecule<3.3.0" \
   && yum clean all \

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ authors:
   - willthames (https://github.com/willthames)
   - Akasurde (https://github.com/akasurde)
 dependencies:
-  kubernetes.core: '>=1.2.0,<1.3.0'
+  kubernetes.core: '>=2.0.0,<2.1.0'
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,7 +10,7 @@
 
     - pip:
         name:
-          - openshift>=0.9.2
+          - kubernetes>=12.0.0
           - coverage
         virtualenv: "{{ virtualenv }}"
         virtualenv_command: "{{ virtualenv_command }}"

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -36,8 +36,8 @@ DOCUMENTATION = '''
               kubeconfig:
                   description:
                   - Path to an existing Kubernetes config file. If not provided, and no other connection
-                    options are provided, the OpenShift client will attempt to load the default
-                    configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
+                    options are provided, the Kubernetes client will attempt to load the default
+                    configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG
                     environment variable.
               context:
                   description:
@@ -85,8 +85,8 @@ DOCUMENTATION = '''
                     to access.
 
     requirements:
-    - "python >= 2.7"
-    - "openshift >= 0.6"
+    - "python >= 3.6"
+    - "kubernetes >= 12.0.0"
     - "PyYAML >= 3.11"
 '''
 
@@ -114,9 +114,10 @@ connections:
 '''
 
 from ansible_collections.kubernetes.core.plugins.inventory.k8s import K8sInventoryException, InventoryModule as K8sInventoryModule, format_dynamic_api_exc
+from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
 
 try:
-    from openshift.dynamic.exceptions import DynamicApiError
+    from kubernetes.dynamic.exceptions import DynamicApiError
 except ImportError:
     pass
 
@@ -135,7 +136,7 @@ class InventoryModule(K8sInventoryModule):
                 raise K8sInventoryException("Expecting connections to be a list.")
 
             for connection in connections:
-                client = self.get_api_client(**connection)
+                client = get_api_client(**connection)
                 name = connection.get('name', self.get_default_host_name(client.configuration.host))
                 if connection.get('namespaces'):
                     namespaces = connection['namespaces']
@@ -144,7 +145,7 @@ class InventoryModule(K8sInventoryModule):
                 for namespace in namespaces:
                     self.get_routes_for_namespace(client, name, namespace)
         else:
-            client = self.get_api_client()
+            client = get_api_client()
             name = self.get_default_host_name(client.configuration.host)
             namespaces = self.get_available_namespaces(client)
             for namespace in namespaces:

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -70,7 +70,7 @@ options:
     type: str
 
 requirements:
-  - python >= 2.7
+  - python >= 3.6
   - urllib3
   - requests
   - requests-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-openshift>=0.6.2
+kubernetes>=12.0.0
 requests-oauthlib

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 collections:
   - name: kubernetes.core
-    version: '>=1.2.0,<1.3.0'
+    version: '>=2.0.0,<2.1.0'


### PR DESCRIPTION
This makes the necessary changes to get the collection working with
kubernetes.core 2.0. The biggest changes here will be switching from the
openshift client to the kubernetes client, and dropping Python 2
support.