### PR TITLE
openshift_route - add support for annotations

### DIFF
--- a/changelogs/fragments/99-openshift_route-add-support-for-annotations.yml
+++ b/changelogs/fragments/99-openshift_route-add-support-for-annotations.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openshift_route - Add support for Route annotations (https://github.com/ansible-collections/community.okd/pull/99).

--- a/molecule/default/tasks/openshift_route.yml
+++ b/molecule/default/tasks/openshift_route.yml
@@ -238,3 +238,36 @@
     namespace: default
     state: absent
     wait: yes
+
+# Route with labels and annotations
+- name: Create route with labels and annotations
+  community.okd.openshift_route:
+    service: hello-kubernetes
+    namespace: default
+    name: route-label-annotation
+    labels:
+      ansible: test
+    annotations:
+      haproxy.router.openshift.io/balance: roundrobin
+
+- name: Get route information
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: route-label-annotation
+    namespace: default
+  register: route
+
+- assert:
+    that:
+      - route.resources[0].metadata.annotations is defined
+      - '"haproxy.router.openshift.io/balance" in route.resources[0].metadata.annotations'
+      - route.resources[0].metadata.labels is defined
+      - '"ansible" in route.resources[0].metadata.labels'
+
+- name: Delete route
+  community.okd.openshift_route:
+    name: route-label-annotation
+    namespace: default
+    state: absent
+    wait: yes

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -56,6 +56,7 @@ options:
       - Specify the Route Annotations.
       - 'A set of key: value pairs.'
     type: dict
+    version_added: "2.1"
   name:
     description:
       - The desired name of the Route to be created.

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -21,7 +21,7 @@ author: "Fabian von Feilitzsch (@fabianvf)"
 description:
   - Looks up a Service and creates a new Route based on it.
   - Analogous to `oc expose` and `oc create route` for creating Routes, but does not support creating Services.
-  - For creating Services from other resources, see kubernetes.core.k8s_expose
+  - For creating Services from other resources, see kubernetes.core.k8s.
 
 extends_documentation_fragment:
   - kubernetes.core.k8s_auth_options
@@ -49,6 +49,11 @@ options:
   labels:
     description:
       - Specify the labels to apply to the created Route.
+      - 'A set of key: value pairs.'
+    type: dict
+  annotations:
+    description:
+      - Specify the Route Annotations.
       - 'A set of key: value pairs.'
     type: dict
   name:
@@ -174,6 +179,8 @@ EXAMPLES = r'''
     service: hello-kubernetes
     namespace: default
     insecure_policy: allow
+    annotations:
+      haproxy.router.openshift.io/balance: roundrobin
   register: route
 '''
 
@@ -372,6 +379,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
             insecure_policy=dict(type='str', choices=['allow', 'redirect', 'disallow'], default='disallow'),
         ))
         spec['termination'] = dict(choices=['edge', 'passthrough', 'reencrypt', 'insecure'], default='insecure')
+        spec['annotations'] = dict(type='dict')
 
         return spec
 
@@ -401,6 +409,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
         path = self.params.get('path')
         wildcard_policy = self.params.get('wildcard_policy')
         port = self.params.get('port')
+        annotations = self.params.get('annotations')
 
         if termination_type and self.params.get('tls'):
             tls_ca_cert = self.params['tls'].get('ca_certificate')
@@ -423,6 +432,9 @@ class OpenShiftRoute(K8sAnsibleMixin):
             },
             'spec': {}
         }
+
+        if annotations:
+            route['metadata']['annotations'] = annotations
 
         if state != 'absent':
             route['spec'] = self.build_route_spec(


### PR DESCRIPTION
``openshift_route`` module now support ``annotations`` options allowing to create route with annotations.
Solves: #75 
example task
```
- openshift_route:
     name: test
     service: my-service
     annotations:
         haproxy.router.openshift.io/balance: source
```