### PR TITLE
Fix broken links for downstream collection

### DIFF
--- a/changelogs/fragments/100-fix-broken-links.yml
+++ b/changelogs/fragments/100-fix-broken-links.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix broken links in Automation Hub for redhat.openshift (https://github.com/openshift/community.okd/issues/100).

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -46,7 +46,7 @@ f_text_sub()
     sed -i.bak "s/^version\:.*$/version: ${DOWNSTREAM_VERSION}/" "${_build_dir}/galaxy.yml"
     sed -i.bak "/STARTREMOVE/,/ENDREMOVE/d" "${_build_dir}/README.md"
 
-    find "${_build_dir}" -type f -exec sed -i.bak "s/community\.okd/redhat\.openshift/g" {} \;
+    find "${_build_dir}" -type f ! -name galaxy.yml -exec sed -i.bak "s/community\.okd/redhat\.openshift/g" {} \;
     find "${_build_dir}" -type f -name "*.bak" -delete
 }
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,12 +9,12 @@ dependencies:
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''
-issues: https://github.com/ansible-collections/community.okd/issues
+issues: https://github.com/openshift/community.okd/issues
 license_file: LICENSE
 name: okd
 namespace: community
 readme: README.md
-repository: https://github.com/ansible-collections/community.okd
+repository: https://github.com/openshift/community.okd
 tags:
   - kubernetes
   - k8s


### PR DESCRIPTION
The links to the repo on Automation Hub are broken for the downstream
collection. This skips the replacement step for galaxy.yml.

Fixes: #100 