### PR TITLE
Enable turbo mode

### DIFF
--- a/changelogs/fragments/102-support-turbo-mode.yaml
+++ b/changelogs/fragments/102-support-turbo-mode.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add support for turbo mode (https://github.com/openshift/community.okd/pull/102).

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -266,7 +266,10 @@ import operator
 import traceback
 from functools import reduce
 
-from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule import AnsibleModule
+except ImportError:
+    from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 try:

--- a/plugins/modules/openshift_process.py
+++ b/plugins/modules/openshift_process.py
@@ -208,7 +208,10 @@ import os
 import copy
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule import AnsibleModule
+except ImportError:
+    from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 try:
@@ -253,6 +256,7 @@ class OpenShiftProcess(K8sAnsibleMixin):
 
         self.params = self.module.params
         self.check_mode = self.module.check_mode
+        self.client = get_api_client(self.module)
 
     @property
     def argspec(self):
@@ -270,8 +274,6 @@ class OpenShiftProcess(K8sAnsibleMixin):
         return spec
 
     def execute_module(self):
-        self.client = get_api_client(self.module)
-
         v1_templates = self.find_resource('templates', 'template.openshift.io/v1', fail=True)
         v1_processed_templates = self.find_resource('processedtemplates', 'template.openshift.io/v1', fail=True)
 

--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -309,7 +309,10 @@ duration:
 import copy
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule import AnsibleModule
+except ImportError:
+    from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 try:
@@ -357,6 +360,7 @@ class OpenShiftRoute(K8sAnsibleMixin):
         self.check_mode = self.module.check_mode
         self.warnings = []
         self.params['merge_type'] = None
+        self.client = get_api_client(self.module)
 
     @property
     def argspec(self):
@@ -385,7 +389,6 @@ class OpenShiftRoute(K8sAnsibleMixin):
         return spec
 
     def execute_module(self):
-        self.client = get_api_client(self.module)
         v1_routes = self.find_resource('Route', 'route.openshift.io/v1', fail=True)
 
         service_name = self.params.get('service')


### PR DESCRIPTION
This enables turbo mode (default is off) for the modules in this
collection that use the client from the kubernetes.core collection.