### PR TITLE
Fix sanity test errors

### DIFF
--- a/plugins/modules/openshift_route.py
+++ b/plugins/modules/openshift_route.py
@@ -56,7 +56,7 @@ options:
       - Specify the Route Annotations.
       - 'A set of key: value pairs.'
     type: dict
-    version_added: "2.1"
+    version_added: "2.1.0"
   name:
     description:
       - The desired name of the Route to be created.


### PR DESCRIPTION
The empty test-requirements.txt file is needed to get Zuul's sanity job
to run.