### PR TITLE
relax the dependency with kubernetes.core

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ authors:
   - willthames (https://github.com/willthames)
   - Akasurde (https://github.com/akasurde)
 dependencies:
-  kubernetes.core: '>=2.1.0,<2.2.0'
+  kubernetes.core: '>=2.1.0'
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''


### PR DESCRIPTION
We can use the collection with the 2.2 branch of kubernetes.core.
