### PR TITLE
shellcheck: SC2236: Use -n instead of ! -z.

### DIFF
--- a/ci/incluster_integration.sh
+++ b/ci/incluster_integration.sh
@@ -13,7 +13,7 @@ NAMESPACE=${NAMESPACE:-default}
 # would resolve to quay.io/mynamespace/molecule-test-runner
 # shellcheck disable=SC2034
 component='molecule-test-runner'
-if [[ ! -z "${MOLECULE_IMAGE}" ]]; then
+if [[ -n "${MOLECULE_IMAGE}" ]]; then
   IMAGE="${MOLECULE_IMAGE}"
 else
   IMAGE="${IMAGE_FORMAT}"


### PR DESCRIPTION
Depends-On: https://github.com/openshift/community.okd/pull/109

Address the following warning:

```
ERROR: Found 1 shellcheck issue(s) which need to be resolved:
ERROR: ci/incluster_integration.sh:16:7: SC2236: Use -n instead of ! -z.
```
