### PR TITLE
gitignore ansible collections dir is used by the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ changelogs/.plugin-cache.yaml
 # Temporary test files.
 tests/output
 tests/integration/cloud-config-*
+
+# Ignore the ansible_collections that the Makefile generates.
+ansible_collections


### PR DESCRIPTION
gitignore: ansible_collections dir is used by the Makefile
