### PR TITLE
pylint: ignore a use-a-generator message

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -396,6 +396,7 @@ class OKDRawModule(K8sAnsibleMixin):
         """ Iterates over keys, returns the first object from objects where the value of the key
             matches the value in desired
         """
+        # pylint: disable=use-a-generator
         for i, item in enumerate(objects):
             if item and all([desired.get(key, True) == item.get(key, False) for key in keys]):
                 return i

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,3 +1,4 @@
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/k8s.py pylint:bad-option-value
 plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,4 @@
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/k8s.py pylint:bad-option-value
 plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,2 +1,3 @@
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py pylint:bad-option-value
 plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
Follow up to the recent upgrade of pylint in the devel branch, we've
got a new use-a-generator error in k8s.py:

Use a generator instead 'all(desired.get(key, True) == item.get(key, False) for key in keys)'

This commit disables the error until we've got time to rewrite this
part.
Also, since the older branches still use an ancient version of pylint,
we've got another message saying the error does not exist (yet!).
This commit also adds the right entries in the ignore files.
