### PR TITLE
fix kubeconfig flag for newer versions

### DIFF
--- a/plugins/connection/oc.py
+++ b/plugins/connection/oc.py
@@ -155,7 +155,7 @@ CONNECTION_TRANSPORT = 'oc'
 CONNECTION_OPTIONS = {
     'oc_container': '-c',
     'oc_namespace': '-n',
-    'oc_kubeconfig': '--config',
+    'oc_kubeconfig': '--kubeconfig',
     'oc_context': '--context',
     'oc_host': '--server',
     'client_cert': '--client-certificate',


### PR DESCRIPTION
I believe this is a backwards compatible change:

```
> podman run -it --rm openshift/origin-cli:v3.11.0 oc --kubeconfig
Error: flag needs an argument: --kubeconfig
```

I don't know if there is a minimum/maximum OCP/OKD version specified to use the connection.

fixes #141 

Signed-off-by: Brady Pratt <bpratt@redhat.com>