### PR TITLE
Copy sanity ignores from 2.13 to 2.14

### DIFF
--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,3 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1488

This partially addresses #146. It does not technically depend on the zuul PR linked here, but we should wait until that PR is merged and the github org enables the new software factory github app to verify and merge this PR.