### PR TITLE
Relax kubernetes.core dependency to >= 2.1.0, < 3.0.0

### DIFF
--- a/changelogs/fragments/149-kubernetes.core-dependency.yml
+++ b/changelogs/fragments/149-kubernetes.core-dependency.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Relax the dependency on kubernetes.core assuming that kubernetes.core sticks to semantic versioning (https://github.com/openshift/community.okd/pull/149)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ authors:
   - willthames (https://github.com/willthames)
   - Akasurde (https://github.com/akasurde)
 dependencies:
-  kubernetes.core: '>=2.1.0,<2.4.0'
+  kubernetes.core: '>=2.1.0,<3.0.0'
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''


### PR DESCRIPTION
Fixes #148. I think this would be the preferred solution to avoid further breakage once kubernetes.core releases another 2.x.0 minor release. Assuming that kubernetes.core sticks to semantic versioning as it promises, this should be no problem - assuming that this collection isn't using any API from kubernetes.core that is explicitly marked as "internal".