### PR TITLE
Relax kubernetes.core dependency to >= 2.1.0, < 2.4.0

### DIFF
--- a/changelogs/fragments/150-kubernetes.core-dependency.yml
+++ b/changelogs/fragments/150-kubernetes.core-dependency.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Relax the dependency on kubernetes.core (https://github.com/openshift/community.okd/pull/150)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ authors:
   - willthames (https://github.com/willthames)
   - Akasurde (https://github.com/akasurde)
 dependencies:
-  kubernetes.core: '>=2.1.0,<2.3.0'
+  kubernetes.core: '>=2.1.0,<2.4.0'
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1519
Fixes #148. This would be the second choice next to #149. It fixes the current incompatibility.