### PR TITLE
Fix integration tests for k8s 2.3

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -186,7 +186,6 @@ f_copy_collection_to_working_dir()
     cp "${_build_dir}"/*.tar.gz ./
     # Install downstream collection into provided path
     if [[ -n ${INSTALL_DOWNSTREAM_COLLECTION_PATH} ]]; then
-        rm -fr "${INSTALL_DOWNSTREAM_COLLECTION_PATH:?}/*"
         f_log_info "Install built collection *.tar.gz into ${INSTALL_DOWNSTREAM_COLLECTION_PATH}"
         ansible-galaxy collection install -p "${INSTALL_DOWNSTREAM_COLLECTION_PATH}" "${_build_dir}"/*.tar.gz
     fi

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -186,6 +186,7 @@ f_copy_collection_to_working_dir()
     cp "${_build_dir}"/*.tar.gz ./
     # Install downstream collection into provided path
     if [[ -n ${INSTALL_DOWNSTREAM_COLLECTION_PATH} ]]; then
+        rm -fr "${INSTALL_DOWNSTREAM_COLLECTION_PATH:?}/*"
         f_log_info "Install built collection *.tar.gz into ${INSTALL_DOWNSTREAM_COLLECTION_PATH}"
         ansible-galaxy collection install -p "${INSTALL_DOWNSTREAM_COLLECTION_PATH}" "${_build_dir}"/*.tar.gz
     fi

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ authors:
   - willthames (https://github.com/willthames)
   - Akasurde (https://github.com/akasurde)
 dependencies:
-  kubernetes.core: '>=2.1.0,<2.3.0'
+  kubernetes.core: '>=2.1.0,<2.4.0'
 description: OKD Collection for Ansible.
 documentation: ''
 homepage: ''

--- a/molecule/default/tasks/openshift_adm_prune_auth_clusterroles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_clusterroles.yml
@@ -49,7 +49,7 @@
   - set_fact:
       api_token: "{{ _secret.resources[0]['metadata']['annotations']['openshift.io/token-secret.value'] }}"
     when: "'openshift.io/token-secret.value' in _secret.resources[0]['metadata']['annotations']"
-  
+
   - set_fact:
       api_token: "{{ _secret.resources[0]['data']['token'] | b64decode }}"
     when: "'token' in _secret.resources[0]['data']"
@@ -65,8 +65,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"nodes is forbidden: User" in error.msg'
+        - '"nodes is forbidden: User" in error.msg'
 
   - name: list Pod for all namespace should failed
     kubernetes.core.k8s_info:
@@ -79,8 +78,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.msg'
+        - '"pods is forbidden: User" in error.msg'
 
   - name: list Pod for test namespace should failed
     kubernetes.core.k8s_info:
@@ -94,8 +92,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.msg'
+        - '"pods is forbidden: User" in error.msg'
 
   - set_fact:
       test_labels:
@@ -158,8 +155,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.msg'
+        - '"pods is forbidden: User" in error.msg'
 
   - name: list Pod for test namespace should succeed
     kubernetes.core.k8s_info:
@@ -247,8 +243,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.msg'
+        - '"pods is forbidden: User" in error.msg'
 
   - name: list Pod for test namespace should failed
     kubernetes.core.k8s_info:
@@ -263,8 +258,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.msg'
+        - '"pods is forbidden: User" in error.msg'
 
   - name: list Node using ServiceAccount
     kubernetes.core.k8s_info:
@@ -281,7 +275,7 @@
       label_selectors:
         - phase=dev
 
-  - name: list Node using ServiceAccount
+  - name: list Node using ServiceAccount should fail
     kubernetes.core.k8s_info:
       api_key: "{{ api_token }}"
       host: "{{ cluster_host }}"
@@ -293,8 +287,7 @@
 
   - assert:
       that:
-        - error is failed
-        # - '"nodes is forbidden: User" in error.msg'
+        - '"nodes is forbidden: User" in error.msg'
 
   always:
     - name: Ensure namespace is deleted

--- a/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
@@ -90,8 +90,7 @@
   
   - assert:
       that:
-        - error is failed
-        # - '"pods is forbidden: User" in error.module_stderr'
+        - '"pods is forbidden: User" in error.module_stderr'
 
   - name: Create a role to manage Pod from namespace "{{ test_ns }}"
     kubernetes.core.k8s:

--- a/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
@@ -208,8 +208,7 @@
   - name: assert pod deletion failed due to forbidden user
     assert:
       that:
-        - result is failed
-        # - '"forbidden: User" in error.module_stderr'
+        - '"forbidden: User" in error.msg'
 
   - name: List Pod
     kubernetes.core.k8s_info:
@@ -289,8 +288,7 @@
   - name: assert user is not authorize to create pod anymore
     assert:
       that:
-        - result is failed
-        # - '"forbidden: User" in error.module_stderr'
+        - '"forbidden: User" in error.msg'
 
   - name: List Pod
     kubernetes.core.k8s_info:
@@ -331,8 +329,7 @@
   - name: assert user is not authorize to list pod anymore
     assert:
       that:
-        - result is failed
-        # - '"forbidden: User" in error.module_stderr'
+        - '"forbidden: User" in error.msg'
 
   always:
     - name: Ensure namespace is deleted

--- a/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
@@ -90,7 +90,7 @@
   
   - assert:
       that:
-        - '"pods is forbidden: User" in error.module_stderr'
+        - '"pods is forbidden: User" in error.msg'
 
   - name: Create a role to manage Pod from namespace "{{ test_ns }}"
     kubernetes.core.k8s:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1523

Previous to
https://github.com/ansible-collections/kubernetes.core/pull/408 an
attempt to list resources for which the user was not authorized resulted
in an unhandled exception. The task now does not fail, but instead
reports the error message.