### PR TITLE
Initialize OpenshiftGroupsSync attributes early

### DIFF
--- a/changelogs/fragments/165-initialize-attributes-early.yml
+++ b/changelogs/fragments/165-initialize-attributes-early.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_adm_groups_sync - initialize OpenshiftGroupSync attributes early to avoid Attribute error (https://github.com/openshift/community.okd/issues/155).

--- a/molecule/default/roles/openshift_adm_groups/tasks/main.yml
+++ b/molecule/default/roles/openshift_adm_groups/tasks/main.yml
@@ -56,6 +56,7 @@
   # ignore_errors: true
   # register: ping_ldap
 
+- include_tasks: "tasks/python-ldap-not-installed.yml"
 - include_tasks: "tasks/rfc2307.yml"
 - include_tasks: "tasks/activeDirectory.yml"
 - include_tasks: "tasks/augmentedActiveDirectory.yml"

--- a/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
+++ b/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
@@ -9,7 +9,6 @@
 
     - set_fact:
         virtualenv: "{{ test_dir }}/virtualenv"
-        virtualenv_command: "virtualenv --python {{ ansible_python_interpreter }}"
 
     - set_fact:
         virtualenv_interpreter: "{{ virtualenv }}/bin/python"

--- a/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
+++ b/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
@@ -1,0 +1,44 @@
+- block:
+    - name: Create temp directory
+      tempfile:
+        state: directory
+      register: test_dir
+
+    - set_fact:
+        test_dir: "{{ test_dir.path }}"
+
+    - set_fact:
+        virtualenv: "{{ test_dir }}/virtualenv"
+        virtualenv_command: "virtualenv --python {{ ansible_python_interpreter }}"
+
+    - set_fact:
+        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+
+    - pip:
+        name:
+          - kubernetes
+        virtualenv: "{{ virtualenv }}"
+        virtualenv_command: "{{ virtualenv_command }}"
+        virtualenv_site_packages: false
+
+    - name: Load test configurations
+      set_fact:
+        configs: "{{ lookup('template', 'rfc2307/sync-config.j2') | from_yaml }}"
+
+    - name: Synchronize Groups without python-ldap
+      community.okd.openshift_adm_groups_sync:
+        config: "{{ configs.simple }}"
+      register: result
+      ignore_errors: true
+
+    - name: Check that module failed gracefully
+      assert:
+        that:
+          - '"Failed to import the required Python library (python-ldap)" in result.msg'
+
+  always:
+    - name: Remove temp directory
+      file:
+        path: "{{ test_dir }}"
+        state: absent
+      ignore_errors: true

--- a/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
+++ b/molecule/default/roles/openshift_adm_groups/tasks/python-ldap-not-installed.yml
@@ -8,15 +8,12 @@
         test_dir: "{{ test_dir.path }}"
 
     - set_fact:
-        virtualenv: "{{ test_dir }}/virtualenv"
-
-    - set_fact:
-        virtualenv_interpreter: "{{ virtualenv }}/bin/python"
+        venv: "{{ test_dir }}/virtualenv"
 
     - pip:
         name:
           - kubernetes
-        virtualenv: "{{ virtualenv }}"
+        virtualenv: "{{ venv }}"
         virtualenv_command: "{{ virtualenv_command }}"
         virtualenv_site_packages: false
 
@@ -29,6 +26,8 @@
         config: "{{ configs.simple }}"
       register: result
       ignore_errors: true
+      vars:
+        ansible_python_interpreter: "{{ venv }}/bin/python"
 
     - name: Check that module failed gracefully
       assert:

--- a/plugins/module_utils/openshift_groups.py
+++ b/plugins/module_utils/openshift_groups.py
@@ -267,6 +267,15 @@ class OpenshiftGroupsSync(K8sAnsibleMixin):
     def __init__(self, module):
 
         self.module = module
+        self.params = self.module.params
+        self.check_mode = self.module.check_mode
+        self.__k8s_group_api = None
+        self.__ldap_connection = None
+        self.host = None
+        self.port = None
+        self.netlocation = None
+        self.scheme = None
+        self.config = self.params.get("sync_config")
 
         if not HAS_KUBERNETES_COLLECTION:
             self.module.fail_json(
@@ -282,17 +291,7 @@ class OpenshiftGroupsSync(K8sAnsibleMixin):
 
         super(OpenshiftGroupsSync, self).__init__(self.module)
 
-        self.params = self.module.params
-        self.check_mode = self.module.check_mode
         self.client = get_api_client(self.module)
-
-        self.__k8s_group_api = None
-        self.__ldap_connection = None
-        self.host = None
-        self.port = None
-        self.netlocation = None
-        self.scheme = None
-        self.config = self.params.get("sync_config")
 
     @property
     def k8s_group_api(self):


### PR DESCRIPTION
Depends-On: https://github.com/openshift/community.okd/pull/167

The fail_json() method calls close_connection(), but this can fail when
the python-ldap library is not installed as close_connection() gets
called before the __ldap_connection attribute has been defined.

Fixes #155.