### PR TITLE
openshift_auth - fix discard token

### DIFF
--- a/changelogs/fragments/178-openshift_auth-fix-revoke-token.yml
+++ b/changelogs/fragments/178-openshift_auth-fix-revoke-token.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_auth - Review the way the discard process is working, add openshift algorithm to convert token to resource object name (https://github.com/openshift/community.okd/issues/176).

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -54,7 +54,7 @@
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: ClusterRole
-            name: cluster-reader
+            name: cluster-admin
           subjects:
             - apiGroup: rbac.authorization.k8s.io
               kind: User

--- a/molecule/default/tasks/openshift_auth.yml
+++ b/molecule/default/tasks/openshift_auth.yml
@@ -1,5 +1,9 @@
 ---
 - block:
+    - set_fact:
+        admin_user: test
+        admin_pass: testing123
+
     - name: Retrieve cluster info
       kubernetes.core.k8s_cluster_info:
       register: k8s_cluster
@@ -10,47 +14,95 @@
 
     - name: Log in (obtain access token)
       community.okd.openshift_auth:
-        username: test
-        password: testing123
+        username: "{{ admin_user }}"
+        password: "{{ admin_pass }}"
         host: '{{ openshift_host }}'
         verify_ssl: false
       register: openshift_auth_results
 
-    - name: Get the test User
+    - set_fact:
+        auth_api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+
+    - name: "Get the {{ admin_user }} User"
       kubernetes.core.k8s_info:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+        api_key: "{{ auth_api_key }}"
         host: '{{ openshift_host }}'
         verify_ssl: false
         kind: User
         api_version: user.openshift.io/v1
-        name: test
+        name: "{{ admin_user }}"
       register: user_result
 
     - name: assert that the user was found
       assert:
         that: (user_result.resources | length) == 1
 
-  always:
-    - name: If login succeeded, try to log out (revoke access token)
-      when: openshift_auth_results.openshift_auth.api_key is defined
+    - name: list available tokens
+      kubernetes.core.k8s_info:
+        kind: UserOAuthAccessToken
+        version: oauth.openshift.io/v1
+      register: tokens
+
+    - debug: var=tokens
+
+    - set_fact:
+        token_names: "{{ tokens.resources | map(attribute='metadata.name') | list }}"
+
+    - debug: var=token_names
+
+    - name: Revoke access token
       community.okd.openshift_auth:
         state: absent
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+        api_key: "{{ auth_api_key }}"
         host: '{{ openshift_host }}'
         verify_ssl: false
+      register: _revoke
 
-    - name: Get the test user
+    - name: Ensure that token has been revoked
+      assert:
+        that:
+          - _revoke is changed
+
+    - name: "Get the {{ admin_user }} User (after token deletion)"
       kubernetes.core.k8s_info:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+        api_key: "{{ auth_api_key }}"
         host: '{{ openshift_host }}'
         verify_ssl: false
         kind: User
-        name: test
         api_version: user.openshift.io/v1
-      register: failed_user_result
-      ignore_errors: yes
+        name: "{{ admin_user }}"
+      ignore_errors: true
+      retries: 50
+      until: user_result is failed
+      delay: 20
+      register: user_result
 
-    # TODO(fabianvf) determine why token is not being rejected, maybe add more info to return
-    # - name: assert that the user was not found
-    #   assert:
-    #     that: (failed_user_result.resources | length) == 0
+    - name: Ensure that task has failed due to revoked token
+      assert:
+        that:
+          - user_result is failed
+
+    - name: Revoke access token once again (should fail)
+      community.okd.openshift_auth:
+        state: absent
+        api_key: "{{ auth_api_key }}"
+        host: '{{ openshift_host }}'
+        verify_ssl: false
+      register: _revoke
+      ignore_errors: true
+
+    - name: Ensure that nothing changed
+      assert:
+        that:
+          - _revoke is failed
+          - _revoke.msg.startswith("Couldn't delete user oauth access token")
+
+  always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: auth_api_key is defined
+      community.okd.openshift_auth:
+        state: absent
+        api_key: "{{ auth_api_key }}"
+        host: '{{ openshift_host }}'
+        verify_ssl: false
+      ignore_errors: true

--- a/molecule/default/tasks/openshift_auth.yml
+++ b/molecule/default/tasks/openshift_auth.yml
@@ -48,54 +48,57 @@
     - set_fact:
         token_names: "{{ tokens.resources | map(attribute='metadata.name') | list }}"
 
-    - debug: var=token_names
+    - block:
+        - debug: var=token_names
 
-    - name: Revoke access token
-      community.okd.openshift_auth:
-        state: absent
-        api_key: "{{ auth_api_key }}"
-        host: '{{ openshift_host }}'
-        verify_ssl: false
-      register: _revoke
+        - name: Revoke access token
+          community.okd.openshift_auth:
+            state: absent
+            api_key: "{{ auth_api_key }}"
+            host: '{{ openshift_host }}'
+            verify_ssl: false
+          register: _revoke
 
-    - name: Ensure that token has been revoked
-      assert:
-        that:
-          - _revoke is changed
+        - name: Ensure that token has been revoked
+          assert:
+            that:
+              - _revoke is changed
 
-    - name: "Get the {{ admin_user }} User (after token deletion)"
-      kubernetes.core.k8s_info:
-        api_key: "{{ auth_api_key }}"
-        host: '{{ openshift_host }}'
-        verify_ssl: false
-        kind: User
-        api_version: user.openshift.io/v1
-        name: "{{ admin_user }}"
-      ignore_errors: true
-      retries: 50
-      until: user_result is failed
-      delay: 20
-      register: user_result
+        - name: "Get the {{ admin_user }} User (after token deletion)"
+          kubernetes.core.k8s_info:
+            api_key: "{{ auth_api_key }}"
+            host: '{{ openshift_host }}'
+            verify_ssl: false
+            kind: User
+            api_version: user.openshift.io/v1
+            name: "{{ admin_user }}"
+          ignore_errors: true
+          retries: 50
+          until: user_result is failed
+          delay: 20
+          register: user_result
 
-    - name: Ensure that task has failed due to revoked token
-      assert:
-        that:
-          - user_result is failed
+        - name: Ensure that task has failed due to revoked token
+          assert:
+            that:
+              - user_result is failed
 
-    - name: Revoke access token once again (should fail)
-      community.okd.openshift_auth:
-        state: absent
-        api_key: "{{ auth_api_key }}"
-        host: '{{ openshift_host }}'
-        verify_ssl: false
-      register: _revoke
-      ignore_errors: true
+        - name: Revoke access token once again (should fail)
+          community.okd.openshift_auth:
+            state: absent
+            api_key: "{{ auth_api_key }}"
+            host: '{{ openshift_host }}'
+            verify_ssl: false
+          register: _revoke
+          ignore_errors: true
 
-    - name: Ensure that nothing changed
-      assert:
-        that:
-          - _revoke is failed
-          - _revoke.msg.startswith("Couldn't delete user oauth access token")
+        - name: Ensure that nothing changed
+          assert:
+            that:
+              - _revoke is failed
+              - _revoke.msg.startswith("Couldn't delete user oauth access token")
+
+      when: token_names | length > 0
 
   always:
     - name: If login succeeded, try to log out (revoke access token)


### PR DESCRIPTION
When removing a token we should not use the token as name but convert it into Openshift resource as it is done on the server side
Fixes #176 