### PR TITLE
add pytest-forked in test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coverage==4.5.4
 pytest
 pytest-xdist
+pytest-forked


### PR DESCRIPTION
Unit tests are failing due to missing library `pytest-forked`