### PR TITLE
Fix example docs for openshift_auth

### DIFF
--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -79,7 +79,7 @@ requirements:
 EXAMPLES = r'''
 - hosts: localhost
   module_defaults:
-    group/k8s:
+    group/community.okd.okd:
       host: https://k8s.example.com/
       ca_cert: ca.pem
   tasks:


### PR DESCRIPTION
This fixes the example for openshift_auth. It was using the incorrect group in module_defaults.

Closes #175