### PR TITLE
Fix failed token deletion

### DIFF
--- a/changelogs/fragments/194-failed-token-deletions.yml
+++ b/changelogs/fragments/194-failed-token-deletions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_auth - fix issue where openshift_auth module sometimes does not delete the auth token (https://github.com/openshift/community.okd/pull/194).

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -224,7 +224,7 @@ def get_oauthaccesstoken_objectname_from_token(token_name):
     """
 
     sha256Prefix = "sha256~"
-    content = token_name.strip(sha256Prefix)
+    content = token_name[len(sha256Prefix):]
 
     b64encoded = urlsafe_b64encode(hashlib.sha256(content.encode()).digest()).rstrip(
         b"="

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -224,7 +224,10 @@ def get_oauthaccesstoken_objectname_from_token(token_name):
     """
 
     sha256Prefix = "sha256~"
-    content = token_name[len(sha256Prefix):]
+    if token_name.startswith(sha256Prefix):
+      content = token_name[len(sha256Prefix):]
+    else:
+      content = token_name
 
     b64encoded = urlsafe_b64encode(hashlib.sha256(content.encode()).digest()).rstrip(
         b"="


### PR DESCRIPTION
Randomly, the openshift_auth module exits in error and does not delete the token.

`Couldn't delete user oauth access token 'sha256~BmhQbi0TLPGJqA15PdLbbfJesJlQX_208Iv9saVpU2U' due to: useroauthaccesstokens.oauth.openshift.io \"sha256~BmhQbi0TLPGJqA15PdLbbfJesJlQX_208Iv9saVpU2U\" not found`

When this happens, the token name does not match the one returned by the Openshift API.
```
$ oc get useroauthaccesstokens
NAME                                                 CLIENT NAME
sha256~CZMJTLYVJAyDWZ4JvOrE48J97xpn0HIstFSDT3yHyWM   openshift-challenging-client
```
Ansible version: core `2.15.3`
Python version: `3.10.8`
Collection community.okd version `2.3.0`

I discovered that it failed because Python strip [_method argument is not a prefix or suffix; rather, all combinations of its values are stripped_](https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip). So if the token begins with a character of the set `sha256~`, the token name is not correctly deducted.