### PR TITLE
Relax the python version in downstream build

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -145,7 +145,7 @@ f_handle_doc_fragments_workaround()
     local rendered_fragments="./rendereddocfragments.txt"
 
     # FIXME: Check Python interpreter from environment variable to work with prow
-    PYTHON=${DOWNSTREAM_BUILD_PYTHON:-/usr/bin/python3.6}
+    PYTHON=${DOWNSTREAM_BUILD_PYTHON:-/usr/bin/python3}
     f_log_info "Using Python interpreter: ${PYTHON}"
 
     # Modules with inherited doc fragments from kubernetes.core that need


### PR DESCRIPTION
Just use python3 during the downstream build process, rather than using a specific version.