### PR TITLE
Running tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ units: install
 	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS) && rm -rf $(INSTALL_PATH)
 
 molecule: install
-	cd $(INSTALL_PATH)/ansible_collections/community/okd && molecule test
+	cd $(INSTALL_PATH)/ansible_collections/community/okd && molecule test && rm -rf $(INSTALL_PATH)
 
 test-integration: upstream-test-integration downstream-test-integration
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ VERSION = 3.0.0
 SANITY_TEST_ARGS ?= --docker --color
 UNITS_TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
-INSTALL_PATH ?= ~/openshift/ansible_collections
-
+# this expression compute the install path once for all the execution
+# See: https://stackoverflow.com/questions/44114466/how-to-declare-a-deferred-variable-that-is-computed-only-once-for-all
+INSTALL_PATH ?= $(eval INSTALL_PATH := $(shell mktemp -d -p ~/))$(INSTALL_PATH)
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz
@@ -21,13 +22,13 @@ install: build
 	ansible-galaxy collection install --force -p $(INSTALL_PATH) community-okd-$(VERSION).tar.gz
 
 sanity: install
-	cd $(INSTALL_PATH)/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
+	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS) && rm -rf $(INSTALL_PATH)
 
 units: install
-	cd $(INSTALL_PATH)/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS)
+	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS) && rm -rf $(INSTALL_PATH)
 
 molecule: install
-	molecule test
+	cd $(INSTALL_PATH)/ansible_collections/community/okd && molecule test
 
 test-integration: upstream-test-integration downstream-test-integration
 

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,25 @@ VERSION = 3.0.0
 SANITY_TEST_ARGS ?= --docker --color
 UNITS_TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
+INSTALL_PATH ?= ~/openshift/ansible_collections
+
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz
 	rm -f redhat-openshift-$(VERSION).tar.gz
-	rm -rf ansible_collections
+	rm -rf $(INSTALL_PATH)
 
 build: clean
 	ansible-galaxy collection build
 
 install: build
-	ansible-galaxy collection install --force -p ansible_collections community-okd-$(VERSION).tar.gz
+	ansible-galaxy collection install --force -p $(INSTALL_PATH) community-okd-$(VERSION).tar.gz
 
 sanity: install
-	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
+	cd $(INSTALL_PATH)/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
 
 units: install
-	cd ansible_collections/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS)
+	cd $(INSTALL_PATH)/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS)
 
 molecule: install
 	molecule test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ UNITS_TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
 # this expression compute the install path once for all the execution
 # See: https://stackoverflow.com/questions/44114466/how-to-declare-a-deferred-variable-that-is-computed-only-once-for-all
-INSTALL_PATH ?= $(eval INSTALL_PATH := $(shell mktemp -d -p ~/))$(INSTALL_PATH)
+INSTALL_PATH ?= $(eval INSTALL_PATH := $(shell mktemp -d))$(INSTALL_PATH)
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz


### PR DESCRIPTION
While trying to run unit tests locally using `make test-units`, the script fails with 

```
FATAL: Cannot run unit tests without "tests/unit/".
make: *** [Makefile:25: units] Error 1
```
This Pull request fixes the issue by updating the location were the upstream collection is installed.
The current installation path is `ansible_collections` this means that when running this script from `$(HOME)/.ansible/collections/ansible_collections/community/okd`, ansible-test will complain because it is expecting something like `~/code/ansible_collections/community/okd`, this fix then update the installation path to `~/openshift/ansible_collections`