### PR TITLE
Add .gitignore to downstream build files

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -62,6 +62,7 @@ f_prep()
 
     # Files to copy downstream (relative repo root dir path)
     _file_manifest=(
+        .gitignore
         CHANGELOG.rst
         galaxy.yml
         LICENSE


### PR DESCRIPTION
This is required for ansible-lint.