### PR TITLE
[backport/stable-3] Add .gitignore to downstream build files (#208)

### DIFF
--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -62,6 +62,7 @@ f_prep()
 
     # Files to copy downstream (relative repo root dir path)
     _file_manifest=(
+        .gitignore
         CHANGELOG.rst
         galaxy.yml
         LICENSE


### PR DESCRIPTION
This is required for ansible-lint.

(cherry picked from commit 7988daff933657e62172a63958ba3cbc35980072)