### PR TITLE
Update community.okd.k8s_module.rst

### DIFF
--- a/docs/community.okd.k8s_module.rst
+++ b/docs/community.okd.k8s_module.rst
@@ -970,6 +970,15 @@ Examples
 
 .. code-block:: yaml
 
+    - name: Create an OCP project
+      community.okd.k8s:
+        state: present
+        resource_definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: testing
+
     - name: Create a k8s namespace
       community.okd.k8s:
         name: testing


### PR DESCRIPTION
docs.ansible.com is managed by Red Hat and I found that the example to create the OCP/OKD project was missing in this hence I have added the below snippet:

```
    - name: Create an OCP project
      community.okd.k8s:
        state: present
        resource_definition:
          apiVersion: project.openshift.io/v1
          kind: Project
          metadata:
            name: testing
```

Please add this to the man pages also.