### PR TITLE
Update k8s.py

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -145,6 +145,15 @@ requirements:
 """
 
 EXAMPLES = r"""
+- name: Create an OCP project
+  community.okd.k8s:
+    state: present
+    resource_definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: testing
+
 - name: Create a k8s namespace
   community.okd.k8s:
     name: testing


### PR DESCRIPTION
docs.ansible.com is managed by Red Hat and I found that the example to create the OCP/OKD project was missing in this hence I have added the below snippet:

    - name: Create an OCP project
      community.okd.k8s:
        state: present
        resource_definition:
          apiVersion: project.openshift.io/v1
          kind: Project
          metadata:
            name: testing

Please add this to the man pages also.