### PR TITLE
Defer removal of inventory/openshift to 5.0.0

### DIFF
--- a/changelogs/fragments/defer_removal_of_inventory_plugin.yaml
+++ b/changelogs/fragments/defer_removal_of_inventory_plugin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory/openshift.py - Defer removal of k8s inventory plugin to version 5.0.0 ().

--- a/changelogs/fragments/defer_removal_of_inventory_plugin.yaml
+++ b/changelogs/fragments/defer_removal_of_inventory_plugin.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - inventory/openshift.py - Defer removal of k8s inventory plugin to version 5.0.0 ().
+  - inventory/openshift.py - Defer removal of k8s inventory plugin to version 5.0.0 (https://github.com/openshift/community.okd/pull/224).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -20,10 +20,10 @@ plugin_routing:
   inventory:
     openshift:
       deprecation:
-        removal_version: 4.0.0
+        removal_version: 5.0.0
         warning_text: >-
             The openshift inventory plugin has been deprecated and
-            will be removed in release 4.0.0.
+            will be removed in release 5.0.0.
   action:
     k8s:
       redirect: kubernetes.core.k8s_info

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -18,10 +18,10 @@ DOCUMENTATION = """
       - Uses openshift.(yml|yaml) YAML configuration file to set parameter values.
 
     deprecated:
-      removed_in: 4.0.0
+      removed_in: 5.0.0
       why: |
         As discussed in U(https://github.com/ansible-collections/kubernetes.core/issues/31), we decided to
-        remove the openshift inventory plugin in release 4.0.0.
+        remove the openshift inventory plugin in release 5.0.0.
       alternative: "Use M(kubernetes.core.k8s_info) and M(ansible.builtin.add_host) instead."
 
     options:
@@ -157,8 +157,8 @@ class InventoryModule(K8sInventoryModule):
         super(InventoryModule, self).fetch_objects(connections)
 
         self.display.deprecated(
-            "The 'openshift' inventory plugin has been deprecated and will be removed in release 4.0.0",
-            version="4.0.0",
+            "The 'openshift' inventory plugin has been deprecated and will be removed in release 5.0.0",
+            version="5.0.0",
             collection_name="community.okd",
         )
 


### PR DESCRIPTION
Defer removal of `inventory/openshift` plugin to version `5.0.0`