### PR TITLE
connection/oc - add option oc_local_env_vars

### DIFF
--- a/changelogs/fragments/20240523-connection-oc-add-support-for-local-env-vars.yml
+++ b/changelogs/fragments/20240523-connection-oc-add-support-for-local-env-vars.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - connection/oc - added support of local enviroment variable that will be used for ``oc`` and may be requried for establishing connections ifself (https://github.com/openshift/community.okd/pull/225).

--- a/ci/downstream_fragments.py
+++ b/ci/downstream_fragments.py
@@ -11,6 +11,12 @@ with open("./rendereddocfragments.txt", 'w') as df_fd:
     with open(sys.argv[2], 'r') as fd:
         json_docs = json.load(fd)
 
+        # ansible-doc has introduced a 'doc.plugin_name' on branch 'stable-2.17'
+        # This change generated the following sanity tests error.
+        # invalid-documentation: DOCUMENTATION.plugin_name: extra keys not allowed @ data['plugin_name'].
+        # This will be removed from the module documentation
+
+        json_docs[sys.argv[1]]['doc'].pop('plugin_name', '')
         json_docs[sys.argv[1]]['doc'].pop('collection', '')
         json_docs[sys.argv[1]]['doc'].pop('filename', '')
         json_docs[sys.argv[1]]['doc'].pop('has_action', '')

--- a/plugins/connection/oc.py
+++ b/plugins/connection/oc.py
@@ -106,6 +106,15 @@ DOCUMENTATION = """
         env:
           - name: K8S_AUTH_TOKEN
           - name: K8S_AUTH_API_KEY
+      oc_local_env_vars:
+        description:
+          - Local environment variable to be passed locally to the oc command line.
+          - Please be aware that this passes information directly on the command line and it could expose sensitive data.
+        default: {}
+        type: dict
+        version_added: 4.0.0
+        vars:
+          - name: ansible_oc_local_env_vars
       client_cert:
         description:
           - Path to a certificate used to authenticate with the API.


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1863
The option `oc_local_env_vars` allow passing local environment variable to ``oc`` command when running connection plugin