### PR TITLE
k8s - Remove support of merge_type=json

### DIFF
--- a/changelogs/fragments/k8s-merge_type=json-removed.yml
+++ b/changelogs/fragments/k8s-merge_type=json-removed.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - k8s - Support for ``merge_type=json`` has been removed in version 4.0.0. Please use ``kubernetes.core.k8s_json_patch`` instead (https://github.com/openshift/community.okd/pull/226).

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -64,9 +64,8 @@ options:
     - Defaults to C(['strategic-merge', 'merge']), which is ideal for using the same parameters
       on resource kinds that combine Custom Resources and built-in resources.
     - mutually exclusive with C(apply)
-    - I(merge_type=json) is deprecated and will be removed in version 3.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
+    - I(merge_type=json) has been removed in version 4.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
     choices:
-    - json
     - merge
     - strategic-merge
     type: list
@@ -293,7 +292,7 @@ def argspec():
     argument_spec.update(AUTH_ARG_SPEC)
     argument_spec.update(WAIT_ARG_SPEC)
     argument_spec["merge_type"] = dict(
-        type="list", elements="str", choices=["json", "merge", "strategic-merge"]
+        type="list", elements="str", choices=["merge", "strategic-merge"]
     )
     argument_spec["validate"] = dict(type="dict", default=None, options=validate_spec())
     argument_spec["append_hash"] = dict(type="bool", default=False)


### PR DESCRIPTION
Remove deprecated feature `merge_type=json`