### PR TITLE
openshift_auth - Fix issue on examples block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ build: clean
 install: build
 	ansible-galaxy collection install --force -p $(INSTALL_PATH) community-okd-$(VERSION).tar.gz
 
+install-docker: build
+	ansible-galaxy collection install --force -p ansible_collections community-okd-$(VERSION).tar.gz
+
 sanity: install
 	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS) && rm -rf $(INSTALL_PATH)
 
@@ -29,6 +32,9 @@ units: install
 
 molecule: install
 	cd $(INSTALL_PATH)/ansible_collections/community/okd && molecule test && rm -rf $(INSTALL_PATH)
+
+molecule-docker: install-docker
+	molecule test
 
 test-integration: upstream-test-integration downstream-test-integration
 
@@ -43,7 +49,7 @@ upstream-test-sanity: sanity
 
 upstream-test-units: units
 
-upstream-test-integration: molecule
+upstream-test-integration: molecule-docker
 
 downstream-test-sanity:
 	./ci/downstream.sh -s

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -50,6 +50,7 @@ f_text_sub()
     sed -i.bak "s/[[:space:]]okd:$/ openshift:/" "${_build_dir}/meta/runtime.yml"
 
     find "${_build_dir}" -type f ! -name galaxy.yml -exec sed -i.bak "s/community\.okd/redhat\.openshift/g" {} \;
+    find "${_build_dir}" -type f ! -name galaxy.yml -exec sed -i.bak "s/group\/redhat\.openshift\.okd/redhat\.openshift\.openshift/g" {} \;
     find "${_build_dir}" -type f -name "*.bak" -delete
 }
 

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -228,7 +228,7 @@ f_test_integration_option()
     f_common_steps
     pushd "${_build_dir}" || return
         f_log_info "INTEGRATION TEST WD: ${PWD}"
-        make molecule
+        make molecule-docker
     popd || return
     f_cleanup
 }


### PR DESCRIPTION
The Examples block from the module uses `group/community.okd.okd` instead of `community.okd.openshift`.
Closes #214 