### PR TITLE
[stable-4] Fix action group documentation issue for downstream build (#232)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,29 +6,26 @@ VERSION = 3.0.1
 SANITY_TEST_ARGS ?= --docker --color
 UNITS_TEST_ARGS ?= --docker --color
 PYTHON_VERSION ?= `python3 -c 'import platform; print("{0}.{1}".format(platform.python_version_tuple()[0], platform.python_version_tuple()[1]))'`
-# this expression compute the install path once for all the execution
-# See: https://stackoverflow.com/questions/44114466/how-to-declare-a-deferred-variable-that-is-computed-only-once-for-all
-INSTALL_PATH ?= $(eval INSTALL_PATH := $(shell mktemp -d))$(INSTALL_PATH)
 
 clean:
 	rm -f community-okd-$(VERSION).tar.gz
 	rm -f redhat-openshift-$(VERSION).tar.gz
-	rm -rf $(INSTALL_PATH)
+	rm -rf ansible_collections
 
 build: clean
 	ansible-galaxy collection build
 
 install: build
-	ansible-galaxy collection install --force -p $(INSTALL_PATH) community-okd-$(VERSION).tar.gz
+	ansible-galaxy collection install --force -p ansible_collections community-okd-$(VERSION).tar.gz
 
 sanity: install
-	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS) && rm -rf $(INSTALL_PATH)
+	cd ansible_collections/community/okd && ansible-test sanity -v --python $(PYTHON_VERSION) $(SANITY_TEST_ARGS)
 
 units: install
-	cd $(INSTALL_PATH)/ansible_collections/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS) && rm -rf $(INSTALL_PATH)
+	cd ansible_collections/community/okd && ansible-test units -v --python $(PYTHON_VERSION) $(UNITS_TEST_ARGS)
 
 molecule: install
-	cd $(INSTALL_PATH)/ansible_collections/community/okd && molecule test && rm -rf $(INSTALL_PATH)
+	molecule test
 
 test-integration: upstream-test-integration downstream-test-integration
 

--- a/ci/downstream.sh
+++ b/ci/downstream.sh
@@ -50,6 +50,7 @@ f_text_sub()
     sed -i.bak "s/[[:space:]]okd:$/ openshift:/" "${_build_dir}/meta/runtime.yml"
 
     find "${_build_dir}" -type f ! -name galaxy.yml -exec sed -i.bak "s/community\.okd/redhat\.openshift/g" {} \;
+    find "${_build_dir}" -type f ! -name galaxy.yml -exec sed -i.bak "s/group\/redhat\.openshift\.okd/redhat\.openshift\.openshift/g" {} \;
     find "${_build_dir}" -type f -name "*.bak" -delete
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `stable-4`:
 - [Fix action group documentation issue for downstream build (#232)](https://github.com/openshift/community.okd/pull/232)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)