### PR TITLE
Fix Failed Token Delete with PEP8 Indent

### DIFF
--- a/changelogs/fragments/242-fix-failed-token-deletion.yml
+++ b/changelogs/fragments/242-fix-failed-token-deletion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_auth - fix issue where openshift_auth module sometimes does not delete the auth token. Based on stale PR (https://github.com/openshift/community.okd/pull/194).

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -224,8 +224,10 @@ def get_oauthaccesstoken_objectname_from_token(token_name):
     """
 
     sha256Prefix = "sha256~"
-    content = token_name.strip(sha256Prefix)
-
+    if token_name.startswith(sha256Prefix):
+        content = token_name[len(sha256Prefix):]
+    else:
+        content = token_name
     b64encoded = urlsafe_b64encode(hashlib.sha256(content.encode()).digest()).rstrip(
         b"="
     )


### PR DESCRIPTION
Based on #194, but with PEP8 Indentation:

@rev3r4nt: 

> Randomly, the openshift_auth module exits in error and does not delete the token.
>
> Couldn't delete user oauth access token 'sha256\~BmhQbi0TLPGJqA15PdLbbfJesJlQX_208Iv9saVpU2U' due to: useroauthaccesstokens.oauth.openshift.io \"sha256~BmhQbi0TLPGJqA15PdLbbfJesJlQX_208Iv9saVpU2U\" not found
>
>When this happens, the token name does not match the one returned by the Openshift API.

Creating "Duplicate" PR to get Indentation change in since changes already passed testing and approval already provided by @seanmalloy.