### PR TITLE
Cherry Pick: Fix Failed Token Delete with PEP8 Indent (#242)

### DIFF
--- a/changelogs/fragments/242-fix-failed-token-deletion.yml
+++ b/changelogs/fragments/242-fix-failed-token-deletion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift_auth - fix issue where openshift_auth module sometimes does not delete the auth token. Based on stale PR (https://github.com/openshift/community.okd/pull/194).

--- a/plugins/modules/openshift_auth.py
+++ b/plugins/modules/openshift_auth.py
@@ -224,8 +224,10 @@ def get_oauthaccesstoken_objectname_from_token(token_name):
     """
 
     sha256Prefix = "sha256~"
-    content = token_name.strip(sha256Prefix)
-
+    if token_name.startswith(sha256Prefix):
+        content = token_name[len(sha256Prefix):]
+    else:
+        content = token_name
     b64encoded = urlsafe_b64encode(hashlib.sha256(content.encode()).digest()).rstrip(
         b"="
     )


### PR DESCRIPTION
This is a cherry-pick of commit 0a266a671646994b6f7f87cf7ba2aa0c39f3b888 from PR #242 to the `stable-4` branch. If this change is accepted I intend to submit a  follow up PR to propose releasing version 4.0.1 that would contain this bug fix.

CC: @HaleCT2 

