### PR TITLE
Update tests for newer version of openshift

### DIFF
--- a/molecule/default/files/nginx.env
+++ b/molecule/default/files/nginx.env
@@ -1,6 +1,7 @@
 # Want to make sure comments don't break it
 export NAME=test123
 NAMESPACE=openshift
+NGINX_VERSION=1.22-ubi8
 
 
 

--- a/molecule/default/tasks/openshift_adm_prune_auth_clusterroles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_clusterroles.yml
@@ -3,6 +3,7 @@
     - set_fact:
         test_sa: "clusterrole-sa"
         test_ns: "clusterrole-ns"
+        test_tn: "clusterrole-tn"
 
     - name: Ensure namespace
       kubernetes.core.k8s:
@@ -26,34 +27,27 @@
             name: "{{ test_sa }}"
             namespace: "{{ test_ns }}"
 
-    - name: Read Service Account
-      kubernetes.core.k8s_info:
-        kind: ServiceAccount
-        namespace: "{{ test_ns }}"
-        name: "{{ test_sa }}"
-      register: result
-
-    - set_fact:
-        secret_token: "{{ result.resources[0]['secrets'][0]['name'] }}"
+    - name: Create SA token
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ test_tn }}"
+            namespace: "{{ test_ns }}"
+            annotations:
+              kubernetes.io/service-account.name: "{{ test_sa }}"
+          type: kubernetes.io/service-account-token
 
     - name: Get secret details
       kubernetes.core.k8s_info:
         kind: Secret
-        namespace: '{{ test_ns }}'
-        name: '{{ secret_token }}'
+        namespace: "{{ test_ns }}"
+        name: "{{ test_tn }}"
       register: _secret
-      retries: 10
-      delay: 10
-      until:
-        - ("'openshift.io/token-secret.value' in _secret.resources[0]['metadata']['annotations']") or ("'token' in _secret.resources[0]['data']")
-
-    - set_fact:
-        api_token: "{{ _secret.resources[0]['metadata']['annotations']['openshift.io/token-secret.value'] }}"
-      when: "'openshift.io/token-secret.value' in _secret.resources[0]['metadata']['annotations']"
 
     - set_fact:
         api_token: "{{ _secret.resources[0]['data']['token'] | b64decode }}"
-      when: "'token' in _secret.resources[0]['data']"
 
     - name: list Node should failed (forbidden user)
       kubernetes.core.k8s_info:

--- a/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
+++ b/molecule/default/tasks/openshift_adm_prune_auth_roles.yml
@@ -4,6 +4,7 @@
         test_ns: "prune-roles"
         sa_name: "roles-sa"
         pod_name: "pod-prune"
+        tn_name: "roles-sa-token"
         role_definition:
           - name: pod-list
             labels:
@@ -50,34 +51,27 @@
             name: '{{ sa_name }}'
             namespace: '{{ test_ns }}'
 
-    - name: Read Service Account
-      kubernetes.core.k8s_info:
-        kind: ServiceAccount
-        namespace: '{{ test_ns }}'
-        name: '{{ sa_name }}'
-      register: sa_out
-
-    - set_fact:
-        secret_token: "{{ sa_out.resources[0]['secrets'][0]['name'] }}"
+    - name: Create SA secret
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ tn_name }}"
+            namespace: "{{ test_ns }}"
+            annotations:
+              kubernetes.io/service-account.name: "{{ sa_name }}"
+          type: kubernetes.io/service-account-token
 
     - name: Get secret details
       kubernetes.core.k8s_info:
         kind: Secret
         namespace: '{{ test_ns }}'
-        name: '{{ secret_token }}'
+        name: '{{ tn_name }}'
       register: r_secret
-      retries: 10
-      delay: 10
-      until:
-        - ("'openshift.io/token-secret.value' in r_secret.resources[0]['metadata']['annotations']") or ("'token' in r_secret.resources[0]['data']")
-
-    - set_fact:
-        api_token: "{{ r_secret.resources[0]['metadata']['annotations']['openshift.io/token-secret.value'] }}"
-      when: "'openshift.io/token-secret.value' in r_secret.resources[0]['metadata']['annotations']"
 
     - set_fact:
         api_token: "{{ r_secret.resources[0]['data']['token'] | b64decode }}"
-      when: "'token' in r_secret.resources[0]['data']"
 
     - name: list resources using service account
       kubernetes.core.k8s_info:

--- a/molecule/default/tasks/openshift_process.yml
+++ b/molecule/default/tasks/openshift_process.yml
@@ -7,6 +7,7 @@
     parameters:
       NAMESPACE: openshift
       NAME: test123
+      NGINX_VERSION: 1.22-ubi8
   register: result
 
 - name: Create the rendered resources

--- a/molecule/default/tasks/openshift_process.yml
+++ b/molecule/default/tasks/openshift_process.yml
@@ -7,7 +7,7 @@
     parameters:
       NAMESPACE: openshift
       NAME: test123
-      NGINX_VERSION: 1.22-ubi8
+      NGINX_VERSION: "{{ nginx_version }}"
   register: result
 
 - name: Create the rendered resources
@@ -33,6 +33,7 @@
     parameters:
       NAMESPACE: openshift
       NAME: test123
+      NGINX_VERSION: "{{ nginx_version }}"
     state: present
     namespace_target: process-test
   register: result
@@ -45,6 +46,7 @@
       NAMESPACE: openshift
       NAME: test123
       MEMORY_LIMIT: 1Gi
+      NGINX_VERSION: "{{ nginx_version }}"
     state: present
     namespace_target: process-test
   register: result
@@ -56,6 +58,7 @@
     parameters:
       NAMESPACE: openshift
       NAME: test123
+      NGINX_VERSION: "{{ nginx_version }}"
     state: absent
     namespace_target: process-test
   register: result

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -77,6 +77,7 @@
         - import_tasks: tasks/openshift_process.yml
           vars:
             files_dir: '{{ playbook_dir }}/files'
+            nginx_version: 1.22-ubi8
       always:
         - name: Delete namespace
           community.okd.k8s:

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,3 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,3 @@
+plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
+plugins/modules/k8s.py validate-modules:return-syntax-error
+plugins/modules/openshift_process.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1908

More recent versions of ocp no longer automatically create tokens for service accounts. This updates the tests to manually create the tokens.